### PR TITLE
Bug sur slug modèle contact corrigé

### DIFF
--- a/blog/contacts/models.py
+++ b/blog/contacts/models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from django.db import models
 from django.conf import settings
 from django_extensions.db.fields import AutoSlugField
@@ -5,7 +7,11 @@ from django.core.validators import MinValueValidator, MaxValueValidator
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
-
+def slugify_with_date(self):
+    """AutoSlugField can't be populated by created_at when contact is saved.
+    We use here datetime.now().
+    """
+    return "{}-{}".format(self.contact_email, datetime.now())
 
 class Contact(models.Model):
     """A model for the contact message is not mandatory. But here, we could
@@ -20,7 +26,7 @@ class Contact(models.Model):
     contact_email = models.EmailField(_("E-mail"))
     slug = AutoSlugField(
         "contact slug",
-        populate_from=['contact_email', 'created_at'],
+        populate_from=slugify_with_date,
         unique=True,
     )
     content = models.TextField(_("message"), blank=False)


### PR DESCRIPTION
AutoSlugField de Django-Extensions ne peut pas prendre en compte la date de création au moment de la sauvegarde en BD.
Mise en place d'une fonction qui utilisera le datetime.now()  