### PR TITLE
éviter doublon de titre d'article

### DIFF
--- a/api/articles/serializers.py
+++ b/api/articles/serializers.py
@@ -14,8 +14,10 @@ class ArticleDetailSerializer(ModelSerializer):
         # être explicite.
         fields = '__all__'
 
-    # def validate_title(self, value):
-    #     if Article.objects.filter(title=value).exists():
-    #         if not self.request.method == 'PUT':
-    #             raise serializers.ValidationError('Article already exists')
-    #     return value
+    def validate_title(self, value):
+        '''Forbid title duplication for articles, but avoid
+        PUT method to be catched.'''
+        if not self.context['request'].method == 'PUT':
+            if Article.objects.filter(title=value).exists():
+                raise serializers.ValidationError('Article already exists')
+        return value

--- a/api/articles/views.py
+++ b/api/articles/views.py
@@ -10,9 +10,3 @@ class ArticleViewset(ModelViewSet):
  
     def get_queryset(self):
         return Article.objects.all()
-
-    # Pour pouvoir faire un update partiel
-    # https://tech.serhatteker.com/post/2020-09/enable-partial-update-drf/
-    # def update(self, request, *args, **kwargs):
-    #     kwargs['partial'] = True
-    #     return super().update(request, *args, **kwargs)


### PR DESCRIPTION
Par l'ajout de la méthode validate_title de  ArticleDetailSerializer on évite que deux articles portent le même titre.
Mais, il est nécessaire de laisser passer les requêtes PUT pour éviter d'être bloqué lors d'une modification qui ne porterait pas sur le titre.