### PR TITLE
Ajout enregistrement automatique auteur côté API

### DIFF
--- a/api/articles/serializers.py
+++ b/api/articles/serializers.py
@@ -8,6 +8,10 @@ class ArticleDetailSerializer(ModelSerializer):
     """Serializer for the Article model wich display the list of articles
     with all elements."""
 
+    author = serializers.HiddenField(
+    default=serializers.CurrentUserDefault()
+    )
+
     class Meta:
         model = Article
         # Normalement tous les champs par défaut, mais ajout de _all_ pour


### PR DESCRIPTION
Ajout d'un champ caché auteur dans le sérializeur d'articles avec affectation de l'auteur authentifié.