### PR TITLE
Affichage username plutôt que ID

### DIFF
--- a/api/articles/serializers.py
+++ b/api/articles/serializers.py
@@ -8,9 +8,7 @@ class ArticleDetailSerializer(ModelSerializer):
     """Serializer for the Article model wich display the list of articles
     with all elements."""
 
-    author = serializers.HiddenField(
-    default=serializers.CurrentUserDefault()
-    )
+    author = serializers.CharField(source='author.username', read_only=True)
 
     class Meta:
         model = Article

--- a/api/articles/views.py
+++ b/api/articles/views.py
@@ -21,3 +21,6 @@ class ArticleViewset(ModelViewSet):
  
     def get_queryset(self):
         return Article.objects.all()
+
+    def perform_create(self, serializer):
+        serializer.save(author=self.request.user)

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -17,7 +17,7 @@ class UserSerializer(ModelSerializer):
         extra_kwargs = {
             'password': {'write_only': True}
         }
-
+        
     # pour s'assurer que password et passorwd2 matchent, on overwrite 
     # la méthode save
     def save(self):


### PR DESCRIPTION
Pour ce faire, une modification de la solution retenue pour sauvegarder le nom de l'auteur a été nécessaire.
La première solution retenue était de placer, dans le ModelSerializer, du détail de l’article, un champ caché pré-rempli.
   author = serializers.HiddenField(default=serializers.CurrentUserDefault())
Cela fonctionne, mais lors de l’affichage des article, le champ a également disparu puisque en Hidden.
Si on le place en CharField (au lieu de HiddenField), le prb n’est pas solutionné car c’est l’utilisateur connecté qui apparaît alors comme auteur de tous les articles, lors de la consultation des articles.
Donc Remplacé par    author = serializers.CharField(source='author.username', read_only=True)
puis une surcharge dans le modelViewSet de 
def perform_create(self, serializer): 
    serializer.save(user=self.request.user)
